### PR TITLE
Allow Workflow Creation Per Supported Language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+working-dir
 repo-results
 launch.json
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you pick Dependabot Security Updates:
 
 10. **OPTIONAL**: If you are a GHES customer, then you will need to set the `GHES` env to `true` and then set `GHES_SERVER_BASE_URL` to the URL of your GHES instance. E.G `https://octodemo.com`.
 
-11. If you are enabling Code Scanning (CodeQL), check the `codeql-analysis.yml` file. This is a sample file; please configure this file to suit your repositories needs.
+11. If you are enabling Code Scanning (CodeQL), check the `codeql-analysis-${language}.yml` file. This is a sample file; please configure this file to suit your repositories needs.
 
 12. Run `yarn install` or `npm install`, which will install the necessary dependencies.
 
@@ -110,7 +110,7 @@ The first step is collecting the repositories you would like to run this script 
 yarn run getRepos // In the `.env` set the `LANGUAGE_TO_CHECK=` to the language. E.G `python`, `javascript`, `go`, `hcl`, etc.
 ```
 
-When using GitHub Actions, we commonly find (especially for non-build languages such as JavaScript) that the `codeql-analysis.yml` file is repeatable and consistent across multiple repositories of the same language. About 80% of the time, teams can reuse the same workflow files for the same language. For Java, C++ that number drops down to about 60% of the time. But the reason why we recommend enabling Code Scanning at bulk via language is the `codeql-analysis.yml` file you propose within the pull request has the highest chance of being most accurate. Even if the file needs changing, the team reviewing the pull request would likely only need to make small changes. We recommend you run this command first to get a list of repositories to enable Code Scanning. After running the command, you are welcome to modify this file. Just make sure it's a valid JSON file if you do edit.
+When using GitHub Actions, we commonly find (especially for non-build languages such as JavaScript) that the `-${language}.yml` file is repeatable and consistent across multiple repositories of the same language. About 80% of the time, teams can reuse the same workflow files for the same language. For Java, C++ that number drops down to about 60% of the time. But the reason why we recommend enabling Code Scanning at bulk via language is the `codeql-analysis-${language}.yml` file you propose within the pull request has the highest chance of being most accurate. Even if the file needs changing, the team reviewing the pull request would likely only need to make small changes. We recommend you run this command first to get a list of repositories to enable Code Scanning. After running the command, you are welcome to modify this file. Just make sure it's a valid JSON file if you do edit.
 
 This script only returns repositories where CodeQL results have not already been uploaded to code scanning. If any CodeQL results have been uploaded to a repositories code scanning feature, that repository will not be returned to this list. The motivation behind this is not to raise pull requests on repositories where CodeQL has already been enabled.
 

--- a/bin/workflows/codeql-analysis-powershell.yml
+++ b/bin/workflows/codeql-analysis-powershell.yml
@@ -1,0 +1,48 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# https://github.com/microsoft/action-psscriptanalyzer
+# For more information on PSScriptAnalyzer in general, see
+# https://github.com/PowerShell/PSScriptAnalyzer
+
+name: PSScriptAnalyzer
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+    branches: ["main", "master"]
+  schedule:
+    - cron: "42 4 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run PSScriptAnalyzer
+        uses: microsoft/psscriptanalyzer-action@v1.1
+        with:
+          # Check https://github.com/microsoft/psscriptanalyzer-action for more info about the options.
+          # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.
+          path: .\
+          recurse: true
+          output: results.sarif
+
+      # Upload the SARIF file generated in the previous step
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -7,7 +7,8 @@ export const generalCommands = (
   repo: string,
   branch: string,
   fileName: string,
-  baseURL: string
+  baseURL: string,
+  codeQLLanguage: string
 ): commands => {
   const commands = [
     // Clean the workspace
@@ -28,9 +29,9 @@ export const generalCommands = (
       command: "git",
       args: [
         ...(platform === "darwin"
-        ? ["clone", "--depth", "1", "--filter=blob:none"]
-        // ? ["clone", "--depth", "1", "--filter=blob:none", "--sparse"]
-          : ["clone"]),
+          ? ["clone", "--depth", "1", "--filter=blob:none"]
+          : // ? ["clone", "--depth", "1", "--filter=blob:none", "--sparse"]
+            ["clone"]),
         `${baseURL}/${owner}/${repo}.git`,
       ],
       cwd: `/${destDir}/${tempDIR}`,
@@ -54,7 +55,7 @@ export const generalCommands = (
         winSeparator(`./bin/workflows/${fileName}`, platform),
         winSeparator(
           `/${destDir}/${tempDIR}/${repo}/` +
-            ".github/workflows/codeql-analysis.yml",
+            `.github/workflows/codeql-analysis-${codeQLLanguage}.yml`,
           platform
         ),
       ],
@@ -65,7 +66,10 @@ export const generalCommands = (
       args: [
         // ...(platform === "darwin" ? ["add", "--sparse"] : ["add"]),
         ...(platform === "darwin" ? ["add"] : ["add"]),
-        winSeparator(".github/workflows/codeql-analysis.yml", platform),
+        winSeparator(
+          `.github/workflows/codeql-analysis-${codeQLLanguage}.yml`,
+          platform
+        ),
       ],
       cwd: `/${destDir}/${tempDIR}/${repo}`,
     },

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -30,8 +30,7 @@ export const generalCommands = (
       args: [
         ...(platform === "darwin"
           ? ["clone", "--depth", "1", "--filter=blob:none"]
-          : // ? ["clone", "--depth", "1", "--filter=blob:none", "--sparse"]
-            ["clone"]),
+          : ["clone"]),
         `${baseURL}/${owner}/${repo}.git`,
       ],
       cwd: `/${destDir}/${tempDIR}`,
@@ -64,7 +63,6 @@ export const generalCommands = (
     {
       command: "git",
       args: [
-        // ...(platform === "darwin" ? ["add", "--sparse"] : ["add"]),
         ...(platform === "darwin" ? ["add"] : ["add"]),
         winSeparator(
           `.github/workflows/codeql-analysis-${codeQLLanguage}.yml`,

--- a/src/utils/commitFile.ts
+++ b/src/utils/commitFile.ts
@@ -60,7 +60,8 @@ export const commitFileMac = async (
       repo,
       branch,
       fileName,
-      authBaseURL
+      authBaseURL,
+      codeQLLanguage
     ) as commands;
     inform(gitCommands);
   } catch (err) {

--- a/src/utils/createBranch.ts
+++ b/src/utils/createBranch.ts
@@ -8,12 +8,14 @@ export const createBranch = async (
   sha: string,
   owner: string,
   repo: string,
+  primaryLanguage: string,
   octokit: Octokit
 ): Promise<string> => {
+  const newRef = `${ref}-${primaryLanguage}`;
   const requestParams = {
     owner,
     repo,
-    ref,
+    ref: newRef,
     sha,
   } as createRefParameters;
 

--- a/src/utils/createPullRequest.ts
+++ b/src/utils/createPullRequest.ts
@@ -12,17 +12,19 @@ export const createPullRequest = async (
   refs: string,
   owner: string,
   repo: string,
-  octokit: Octokit
+  octokit: Octokit,
+  language: string
 ): Promise<string> => {
   const regExpExecArray = /[^/]*$/.exec(refs);
   const head = regExpExecArray ? regExpExecArray[0] : "";
 
+  let newTitle = `${title} (${language})`;
   const requestParams = {
     owner,
     repo,
     head,
     base,
-    title,
+    title: newTitle,
   } as createPullRequestParameters;
 
   try {

--- a/src/utils/enableIssueCreation.ts
+++ b/src/utils/enableIssueCreation.ts
@@ -6,7 +6,8 @@ export const enableIssueCreation = async (
   pr: string,
   owner: string,
   repo: string,
-  octokit: Octokit
+  octokit: Octokit,
+  language: string
 ): Promise<void> => {
   const number = pr.split("/").at(-1) as string;
   const body = issueText(pr, number);
@@ -15,7 +16,7 @@ export const enableIssueCreation = async (
     {
       owner,
       repo,
-      title: "GitHub Advanced Security - Code Scanning Enablement :wave:",
+      title: `GitHub Advanced Security - Code Scanning Enablement (${language}) :wave:`,
       body,
     }
   );

--- a/src/utils/findDefaultBranch.ts
+++ b/src/utils/findDefaultBranch.ts
@@ -7,7 +7,7 @@ import {
   listDefaultBranchResponse,
 } from "./octokitTypes";
 
-export const findDefulatBranch = async (
+export const findDefaultBranch = async (
   owner: string,
   repo: string,
   octokit: Octokit

--- a/src/utils/findDefaultBranchSHA.ts
+++ b/src/utils/findDefaultBranchSHA.ts
@@ -7,7 +7,7 @@ import {
   listDefaultBranchSHAResponse,
 } from "./octokitTypes";
 
-export const findDefulatBranchSHA = async (
+export const findDefaultBranchSHA = async (
   defaultBranch: string,
   owner: string,
   repo: string,

--- a/src/utils/getcodeQLLanguage.ts
+++ b/src/utils/getcodeQLLanguage.ts
@@ -33,6 +33,9 @@ export const getcodeQLLanguage = (primaryLanguage: string): string => {
       // hcl == terraform
       codeQLLang = "hcl";
       break;
+    case "powershell":
+      codeQLLang = "powershell";
+      break;
     default:
       codeQLLang = "no-language";
       break;

--- a/src/utils/graphql/getAllRepositoriesInOrganisation.ts
+++ b/src/utils/graphql/getAllRepositoriesInOrganisation.ts
@@ -1,5 +1,5 @@
 export const getRepositoriesQuery = (): string => {
-  const query = ` 
+  const query = `
   query getRepositoriesQuery($slug: String!, $after: String, $first: Int = 100) {
     viewer {
       login
@@ -18,9 +18,11 @@ export const getRepositoriesQuery = (): string => {
           isArchived
           viewerPermission
           visibility
-          primaryLanguage {
+          languages(first: $first) {
+            nodes {
               name
             }
+          }
         }
         totalCount
         pageInfo {

--- a/src/utils/paginateQuery.ts
+++ b/src/utils/paginateQuery.ts
@@ -89,21 +89,16 @@ const getRepositoryInOrganizationPaginate = async (
       inform(
         `Repo Name: ${nameWithOwner} Permission: ${viewerPermission} Archived: ${isArchived} Language: ${name} Visibility: ${visibility}`
       );
-      const languageCheck = process.env.LANGUAGE_TO_CHECK
+      const languageCheck = (process.env.LANGUAGE_TO_CHECK || "")
         ? name.toLocaleLowerCase() === `${process.env.LANGUAGE_TO_CHECK}`
         : true;
-      const publicRepoCheck =
-        process.env.GHES === "true"
-          ? true
-          : visibility === "PRIVATE" || visibility === "INTERNAL"
-          ? true
-          : false;
-      return (viewerPermission === "ADMIN" || viewerPermission === null) &&
+      let returnValue = (viewerPermission === "ADMIN" || viewerPermission === null) &&
         isArchived === false &&
-        languageCheck &&
-        publicRepoCheck
+        languageCheck
         ? true
         : false;
+
+      return returnValue;
     });
 
     inform(

--- a/src/utils/paginateQuery.ts
+++ b/src/utils/paginateQuery.ts
@@ -35,8 +35,8 @@ const performRepositoryQuery = async (
     })) as GraphQlQueryResponseData;
 
     let currentNodes = nodes as Array<GraphQLQueryResponseGetReposRaw>;
-    console.log(nodes)
     let newNodes = new Array<GraphQLQueryResponseGetRepos>();
+
     currentNodes.forEach(node => {
       node.languages.nodes.forEach(lang => {
         const newNode: GraphQLQueryResponseGetRepos = {

--- a/src/utils/worker.ts
+++ b/src/utils/worker.ts
@@ -15,7 +15,6 @@ import { enableDependabotAlerts } from "./enableDependabotAlerts";
 import { enableDependabotFixes } from "./enableDependabotUpdates";
 import { enableIssueCreation } from "./enableIssueCreation";
 import { auth as generateAuth } from "./clients";
-// import { checkIfCodeQLHasAlreadyRanOnRepo } from "./checkCodeQLEnablement";
 
 import { Octokit } from "@octokit/core";
 import { inform, reposFileLocation } from "./globals.js";
@@ -96,21 +95,6 @@ export const worker = async (): Promise<unknown> => {
 
       // Kick off the process for enabling Code Scanning only if it is set to be enabled AND the primary language for the repo exists. If it doesn't exist that means CodeQL doesn't support it.
       if (enableCodeScanning && primaryLanguage != "no-language") {
-        // First, let's check and see if CodeQL has already ran on that repository. If it has, we don't need to do anything.
-        // const codeQLAlreadyRan = await checkIfCodeQLHasAlreadyRanOnRepo(
-        //   owner,
-        //   repo,
-        //   client
-        // );
-
-        // inform(
-        //   `Has ${owner}/${repo} had a CodeQL scan uploaded? ${codeQLAlreadyRan}`
-        // );
-
-        // if (!codeQLAlreadyRan) {
-        // inform(
-        //   `As ${owner}/${repo} hasn't had a CodeQL Scan, going to run CodeQL enablement`
-        // );
         const defaultBranch = await findDefaultBranch(owner, repo, client);
         const defaultBranchSHA = await findDefaultBranchSHA(
           defaultBranch,

--- a/src/utils/worker.ts
+++ b/src/utils/worker.ts
@@ -2,8 +2,8 @@
 
 import { readFileSync } from "node:fs";
 
-import { findDefulatBranch } from "./findDefaultBranch.js";
-import { findDefulatBranchSHA } from "./findDefaultBranchSHA.js";
+import { findDefaultBranch } from "./findDefaultBranch.js";
+import { findDefaultBranchSHA } from "./findDefaultBranchSHA.js";
 import { createBranch } from "./createBranch.js";
 import { enableSecretScanningAlerts } from "./enableSecretScanning";
 import { createPullRequest } from "./createPullRequest.js";
@@ -15,7 +15,7 @@ import { enableDependabotAlerts } from "./enableDependabotAlerts";
 import { enableDependabotFixes } from "./enableDependabotUpdates";
 import { enableIssueCreation } from "./enableIssueCreation";
 import { auth as generateAuth } from "./clients";
-import { checkIfCodeQLHasAlreadyRanOnRepo } from "./checkCodeQLEnablement";
+// import { checkIfCodeQLHasAlreadyRanOnRepo } from "./checkCodeQLEnablement";
 
 import { Octokit } from "@octokit/core";
 import { inform, reposFileLocation } from "./globals.js";
@@ -97,42 +97,55 @@ export const worker = async (): Promise<unknown> => {
       // Kick off the process for enabling Code Scanning only if it is set to be enabled AND the primary language for the repo exists. If it doesn't exist that means CodeQL doesn't support it.
       if (enableCodeScanning && primaryLanguage != "no-language") {
         // First, let's check and see if CodeQL has already ran on that repository. If it has, we don't need to do anything.
-        const codeQLAlreadyRan = await checkIfCodeQLHasAlreadyRanOnRepo(
+        // const codeQLAlreadyRan = await checkIfCodeQLHasAlreadyRanOnRepo(
+        //   owner,
+        //   repo,
+        //   client
+        // );
+
+        // inform(
+        //   `Has ${owner}/${repo} had a CodeQL scan uploaded? ${codeQLAlreadyRan}`
+        // );
+
+        // if (!codeQLAlreadyRan) {
+        // inform(
+        //   `As ${owner}/${repo} hasn't had a CodeQL Scan, going to run CodeQL enablement`
+        // );
+        const defaultBranch = await findDefaultBranch(owner, repo, client);
+        const defaultBranchSHA = await findDefaultBranchSHA(
+          defaultBranch,
           owner,
           repo,
           client
         );
-
-        inform(
-          `Has ${owner}/${repo} had a CodeQL scan uploaded? ${codeQLAlreadyRan}`
+        const ref = await createBranch(
+          defaultBranchSHA,
+          owner,
+          repo,
+          primaryLanguage,
+          client
         );
-
-        if (!codeQLAlreadyRan) {
-          inform(
-            `As ${owner}/${repo} hasn't had a CodeQL Scan, going to run CodeQL enablement`
-          );
-          const defaultBranch = await findDefulatBranch(owner, repo, client);
-          const defaultBranchSHA = await findDefulatBranchSHA(
-            defaultBranch,
+        const authToken = (await generateAuth()) as string;
+        await commitFileMac(owner, repo, primaryLanguage, ref, authToken);
+        const pullRequestURL = await createPullRequest(
+          defaultBranch,
+          ref,
+          owner,
+          repo,
+          client,
+          primaryLanguage
+        );
+        if (createIssue) {
+          await enableIssueCreation(
+            pullRequestURL,
             owner,
             repo,
-            client
+            client,
+            primaryLanguage
           );
-          const ref = await createBranch(defaultBranchSHA, owner, repo, client);
-          const authToken = (await generateAuth()) as string;
-          await commitFileMac(owner, repo, primaryLanguage, ref, authToken);
-          const pullRequestURL = await createPullRequest(
-            defaultBranch,
-            ref,
-            owner,
-            repo,
-            client
-          );
-          if (createIssue) {
-            await enableIssueCreation(pullRequestURL, owner, repo, client);
-          }
-          await writeToFile(pullRequestURL);
         }
+        await writeToFile(pullRequestURL);
+        // }
       }
     }
   }

--- a/tests/findDefaultBranch.test.ts
+++ b/tests/findDefaultBranch.test.ts
@@ -1,4 +1,4 @@
-import { findDefulatBranch } from "../src/utils/findDefaultBranch";
+import { findDefaultBranch } from "../src/utils/findDefaultBranch";
 
 import { octokit } from "../src/utils/octokit";
 
@@ -38,7 +38,7 @@ describe("Default Branch", () => {
         })
     );
 
-    const response = await findDefulatBranch(repo, client);
+    const response = await findDefaultBranch(repo, client);
     expect(response).toStrictEqual(data.data.default_branch);
   });
   it("Error in getting default branch", async () => {
@@ -54,7 +54,7 @@ describe("Default Branch", () => {
     );
 
     try {
-      await findDefulatBranch(repo, client);
+      await findDefaultBranch(repo, client);
     } catch (error: any) {
       expect(error.message).toEqual("Error finding default branch");
     }

--- a/tests/findDefaultBranchSHA.test.ts
+++ b/tests/findDefaultBranchSHA.test.ts
@@ -1,4 +1,4 @@
-import { findDefulatBranchSHA } from "../src/utils/findDefaultBranchSHA";
+import { findDefaultBranchSHA } from "../src/utils/findDefaultBranchSHA";
 
 import { octokit } from "../src/utils/octokit";
 
@@ -41,7 +41,7 @@ describe("Default Branch SHA", () => {
         })
     );
 
-    const response = await findDefulatBranchSHA(defaultBranch, repo, client);
+    const response = await findDefaultBranchSHA(defaultBranch, repo, client);
     expect(response).toStrictEqual(data.data.object.sha);
   });
 
@@ -58,7 +58,7 @@ describe("Default Branch SHA", () => {
     );
 
     try {
-      await findDefulatBranchSHA(defaultBranch, repo, client);
+      await findDefaultBranchSHA(defaultBranch, repo, client);
     } catch (error: any) {
       expect(error.message).toEqual("Error finding default branch SHA");
     }

--- a/types/common/index.d.ts
+++ b/types/common/index.d.ts
@@ -112,6 +112,22 @@ type Func = (
 
 type GetGraphQLQueryFunction = () => string;
 
+export type GraphQLQueryResponseGetReposRaw = {
+  nameWithOwner: string;
+  isArchived: boolean;
+  viewerPermission: string;
+  visibility: string;
+  languages: Languages
+}
+
+export type Languages = {
+  nodes: LanguagesNode[];
+}
+
+export type LanguagesNode = {
+  name: string;
+}
+
 export type GraphQLQueryResponseGetRepos = {
   nameWithOwner: string;
   isArchived: boolean;
@@ -123,5 +139,4 @@ export type GraphQLQueryResponseGetRepos = {
 };
 
 export type GraphQLQueryResponseData = GraphQLQueryResponseGetRepos[];
-
 export type GraphQLQueryResponse = [string, string, GraphQLQueryResponseData];


### PR DESCRIPTION
# Summary of PR changes
When retrieving repos without specifying a language allow the tool to create a scanning workflow for each supported language.

To accomplish this the following changes have been made:
- append language name to the workflow file
- create the same branch name each time for the repo / language combination
- change the graphql query to include all languages in the repo; not just the primary one
- allow this code to be run over and over again, even if a scan has been created.
- created new type that supports bringing in the names of all languages. This type is then converted to the expected type so we don't have to change how the tool works too much.
- adding support for Powershell too
