### PR TITLE
Add jobs to templates

### DIFF
--- a/bin/workflows/template-cs.yml
+++ b/bin/workflows/template-cs.yml
@@ -1,43 +1,44 @@
-CodeQL-Scan-csharp:
-  runs-on: RUNS_ON_PLACEHOLDER
+jobs:
+  CodeQL-Scan-csharp:
+    runs-on: RUNS_ON_PLACEHOLDER
 
-  permissions:
-    actions: read # only required for workflows in private repositories
-    contents: read # for actions/checkout fetch code
-    pull-requests: write # can write to pull requests
-    security-events: write # required for all workflows
+    permissions:
+      actions: read # only required for workflows in private repositories
+      contents: read # for actions/checkout fetch code
+      pull-requests: write # can write to pull requests
+      security-events: write # required for all workflows
 
-  steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        ram: 1024
-        # Using additional queries to get more results
-        # See https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#using-queries-in-ql-packs
-        queries: security-and-quality
-        languages: csharp
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          ram: 1024
+          # Using additional queries to get more results
+          # See https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#using-queries-in-ql-packs
+          queries: security-and-quality
+          languages: csharp
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below).
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below).
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following
-    #    three lines and modify them (or add more) to build your code if your
-    #    project uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following
+      #    three lines and modify them (or add more) to build your code if your
+      #    project uses a compiled language
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: /codeql-scan:csharp
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: /codeql-scan:csharp

--- a/bin/workflows/template-other-langs.yml
+++ b/bin/workflows/template-other-langs.yml
@@ -1,47 +1,48 @@
-CodeQL-Scan:
-  strategy:
-    matrix:
-      languages: [MATRIX_LANGS_PLACEHOLDER]
+jobs:
+  CodeQL-Scan:
+    strategy:
+      matrix:
+        languages: [MATRIX_LANGS_PLACEHOLDER]
 
-  runs-on: im-ghas-linux
+    runs-on: im-ghas-linux
 
-  permissions:
-    actions: read # only required for workflows in private repositories
-    contents: read # for actions/checkout fetch code
-    pull-requests: write # can write to pull requests
-    security-events: write # required for all workflows
+    permissions:
+      actions: read # only required for workflows in private repositories
+      contents: read # for actions/checkout fetch code
+      pull-requests: write # can write to pull requests
+      security-events: write # required for all workflows
 
-  steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        ram: 1024
-        # Using additional queries to get more results
-        # See https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#using-queries-in-ql-packs
-        queries: security-and-quality
-        languages: ${{ matrix.languages }}
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          ram: 1024
+          # Using additional queries to get more results
+          # See https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#using-queries-in-ql-packs
+          queries: security-and-quality
+          languages: ${{ matrix.languages }}
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below).
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below).
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following
-    #    three lines and modify them (or add more) to build your code if your
-    #    project uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following
+      #    three lines and modify them (or add more) to build your code if your
+      #    project uses a compiled language
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: /codeql-scan:${{ matrix.languages }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: /codeql-scan:${{ matrix.languages }}

--- a/bin/workflows/template-ps1.yml
+++ b/bin/workflows/template-ps1.yml
@@ -33,6 +33,6 @@ jobs:
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
-              repo: context.repo.repo
+              repo: context.repo.repo,
               body: 'To view PowerShell rules go to [PSScriptAnalyzer Rules](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/docs/Rules/README.md).'
             })

--- a/bin/workflows/template-ps1.yml
+++ b/bin/workflows/template-ps1.yml
@@ -1,26 +1,27 @@
-PowerShell-Scan:
-  runs-on: im-ghas-linux
+jobs:
+  PowerShell-Scan:
+    runs-on: im-ghas-linux
 
-  permissions:
-    actions: read # only required for workflows in private repositories
-    contents: read # for actions/checkout fetch code
-    pull-requests: write # can write to pull requests
-    security-events: write # required for all workflows
+    permissions:
+      actions: read # only required for workflows in private repositories
+      contents: read # for actions/checkout fetch code
+      pull-requests: write # can write to pull requests
+      security-events: write # required for all workflows
 
-  steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Perform PowerShell Scan
-      uses: microsoft/psscriptanalyzer-action@v1.1
-      with:
-        # Check https://github.com/microsoft/psscriptanalyzer-action for more info about the options.
-        # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.
-        path: .\
-        recurse: true
-        output: powershellresults.sarif
+      - name: Perform PowerShell Scan
+        uses: microsoft/psscriptanalyzer-action@v1.1
+        with:
+          # Check https://github.com/microsoft/psscriptanalyzer-action for more info about the options.
+          # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.
+          path: .\
+          recurse: true
+          output: powershellresults.sarif
 
-    - name: Upload PowerShell SARIF results
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: powershellresults.sarif
+      - name: Upload PowerShell SARIF results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: powershellresults.sarif

--- a/bin/workflows/template-ps1.yml
+++ b/bin/workflows/template-ps1.yml
@@ -25,3 +25,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: powershellresults.sarif
+
+      - name: PowerShell Rules Lookup Comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+              body: 'To view PowerShell rules go to [PSScriptAnalyzer Rules](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/docs/Rules/README.md).'
+            })

--- a/bin/workflows/template-tf.yml
+++ b/bin/workflows/template-tf.yml
@@ -1,22 +1,23 @@
-Terraform-Scan:
-  runs-on: im-ghas-linux
+jobs:
+  Terraform-Scan:
+    runs-on: im-ghas-linux
 
-  permissions:
-    actions: read # only required for workflows in private repositories
-    contents: read # for actions/checkout fetch code
-    pull-requests: write # can write to pull requests
-    security-events: write # required for all workflows
+    permissions:
+      actions: read # only required for workflows in private repositories
+      contents: read # for actions/checkout fetch code
+      pull-requests: write # can write to pull requests
+      security-events: write # required for all workflows
 
-  steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Perform Terraform Scan
-      uses: aquasecurity/tfsec-sarif-action@v0.1.4
-      with:
-        sarif_file: tfsec.sarif
+      - name: Perform Terraform Scan
+        uses: aquasecurity/tfsec-sarif-action@v0.1.4
+        with:
+          sarif_file: tfsec.sarif
 
-    - name: Upload Terraform SARIF results
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: tfsec.sarif
+      - name: Upload Terraform SARIF results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: tfsec.sarif

--- a/bin/workflows/template-tf.yml
+++ b/bin/workflows/template-tf.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # Go to https://aquasecurity.github.io/tfsec/v1.28.1/checks/azure/ to see check expectations
       - name: Perform Terraform Scan
         uses: aquasecurity/tfsec-sarif-action@v0.1.4
         with:
@@ -21,3 +22,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: tfsec.sarif
+
+      - name: Tfsec Rules Lookup Comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+              body: 'To view tfsec checks go to [tfsec azure checks](https://aquasecurity.github.io/tfsec/v1.28.1/checks/azure/).'
+            })

--- a/bin/workflows/template-tf.yml
+++ b/bin/workflows/template-tf.yml
@@ -30,6 +30,6 @@ jobs:
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
-              repo: context.repo.repo
+              repo: context.repo.repo,
               body: 'To view tfsec checks go to [tfsec azure checks](https://aquasecurity.github.io/tfsec/v1.28.1/checks/azure/).'
             })

--- a/src/utils/commitFile.ts
+++ b/src/utils/commitFile.ts
@@ -62,6 +62,13 @@ const doesCodeScanRequireWindowsRunner = (repoName: string): boolean => {
   return requiresWindows;
 };
 
+const addWorkflowJob = (template: string, workflowParts: Array<string>) => {
+  // job templates start with jobs: on the first line so they don't
+  // lose their tab spacing as they are stored. Remove this and add to array
+  const templateWithoutJobs = template.replace("jobs:", "");
+  workflowParts.push(templateWithoutJobs);
+};
+
 const createWorkflowFile = (
   primaryLanguage: string,
   requiresWindows: boolean
@@ -79,13 +86,13 @@ const createWorkflowFile = (
         placeholderRunsOn,
         requiresWindows ? runs_on_windows : runs_on_linux
       );
-      workflowParts.push(templateCsWithReplacements);
+      addWorkflowJob(templateCsWithReplacements, workflowParts);
     } else if (languageTrim == "hcl") {
       // Create terraform scan job
-      workflowParts.push(templateTf);
+      addWorkflowJob(templateTf, workflowParts);
     } else if (languageTrim == "powershell") {
       // Create PowerShell scan job
-      workflowParts.push(templatePwsh);
+      addWorkflowJob(templatePwsh, workflowParts);
     } else if (
       ["go", "javascript", "python", "cpp", "java", "ruby"].includes(
         languageTrim
@@ -103,7 +110,7 @@ const createWorkflowFile = (
       placeholderMatrixLangs,
       matrixLangs
     );
-    workflowParts.push(templateOtherWithReplacements);
+    addWorkflowJob(templateOtherWithReplacements, workflowParts);
   }
 
   // join list as a string separating list items by new line


### PR DESCRIPTION
# Summary of PR changes
- For templates add `jobs:` to them. This will allow the file to preserve its tab spacing after the built-in action formats the files. 
- A new function has been added to add template jobs to the name workflow. It will remove the `jobs:` string before adding jobs.
- Add comment to PR for both PowerShell and Terraform scanners that lead to check rule documentation. 