### PR TITLE
Typo Fix to Get JavaScript Code Scans Working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+problems-seen.txt
 prs.testing.txt
 bin/workflows/code-analysis.yml
 working-dir

--- a/py_helpers/repos_batcher.py
+++ b/py_helpers/repos_batcher.py
@@ -21,7 +21,7 @@ class ReposBatcher(RunnableClass):
         self.name_org_repo_lang_results = "all-results-for-orgs-and"
         self.batch_repo_limit = self.envs.repos_per_batch
         self.code_scan_langs = {
-            "javascript": "javscript",
+            "javascript": "javsacript",
             "java": "java",
             "go": "go",
             "python": "python",


### PR DESCRIPTION
The new repos.json creation path introduced a bug that prevented JavaScript code scans from happening. To fix this the word `javscript` was changed to `javascript`. This fix has been applied to affected PRs and is what is being run for GHAS enablement currently. 